### PR TITLE
HRANA-T-46 Publishing to Maven Central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,8 @@ val spaceUsername: String? by project
 val spacePassword: String? by project
 val sdkVersion: String by project
 val spaceMavenRepositoryUrl: String by project
+val sonatypeUsername: String by project
+val sonatypePassword: String by project
 
 group = "com.jeliuc"
 version = System.getenv("SDK_VERSION") ?: sdkVersion
@@ -21,9 +23,11 @@ plugins {
 
     id("org.jlleitschuh.gradle.ktlint").version("12.0.3")
     id("org.jetbrains.dokka") version "1.9.10"
+    id("net.thebugmc.gradle.sonatype-central-portal-publisher") version "1.2.2"
 
     `maven-publish`
     `kotlin-dsl`
+    signing
 }
 
 repositories {
@@ -110,10 +114,59 @@ publishing {
     repositories {
         maven {
             url = uri(spaceMavenRepositoryUrl)
+            name = "space"
             credentials {
                 username = System.getenv("SPACE_USERNAME") ?: spaceUsername
                 password = System.getenv("SPACE_PASSWORD") ?: spacePassword
             }
+        }
+    }
+}
+
+signing {
+    useGpgCmd()
+}
+
+centralPortal {
+    username = sonatypeUsername
+    password = sonatypePassword
+    name = "turso-sdk-jvm"
+
+    sourcesJarTask =
+        tasks.create<Jar>("sourcesEmptyJar") {
+            archiveClassifier = "sources"
+        }
+
+    javadocJarTask =
+        tasks.create<Jar>("javadocEmptyJar") {
+            archiveClassifier = "javadoc"
+        }
+
+    pom {
+        name = "Turso Platform SDK"
+        description = "Kotlin library for developing applications using Turso Platform API."
+        url = "https://github.com/Jeliuc-Labs/turso-sdk"
+        licenses {
+            license {
+                name.set("Apache-2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+
+        developers {
+            developer {
+                id = "a2xchip"
+                name = "Alexandr Jeliuc"
+                email = "alex@jeliuc.com"
+                organization = "Jeliuc.com S.R.L."
+                organizationUrl = "https://jeliuc.com"
+            }
+        }
+
+        scm {
+            connection.set("scm:git:git://github.com/Jeliuc-Labs/turso-sdk.git")
+            developerConnection.set("scm:git:ssh://github.com/Jeliuc-Labs/turso-sdk.git")
+            url = "https://github.com/Jeliuc-Labs/turso-sdk"
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,8 @@
 kotlin.code.style=official
 ktorVersion=2.3.6
-sdkVersion=0.1.10
+sdkVersion=0.1.11
 spaceUsername=
 spacePassword=
 spaceMavenRepositoryUrl=
+sonatypeUsername=
+sonatypePassword=


### PR DESCRIPTION
Configured publishing to Maven Central. Available now as `com.jeliuc:turso-sdk-jvm:0.1.11`